### PR TITLE
Match filters by account number instead of account id

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -17,8 +17,9 @@ class Filter < ApplicationRecord
   has_many :event_types, :through => :event_type_filters, :dependent => :destroy, :inverse_of => :filters
 
   scope(:matching_message, lambda do |message|
-    left_outer_joins(:apps, :event_types, :levels)
-      .where(:enabled => true, :account_id => message.account_id)
+    left_outer_joins(:apps, :event_types, :levels, :account)
+      .where(:enabled => true)
+      .merge(Account.where(:account_number => message.account_id))
       .merge(App.where(:name => [message.application, nil]))
       .merge(EventType.where(:external_id => [message.event_type, nil]))
       .merge(Level.where(:external_id => [message.level, nil]))

--- a/test/factories/account_factory.rb
+++ b/test/factories/account_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :account, :class => ::Account do
-    sequence(:account_number) { |i| format '%05d', i }
+    sequence(:account_number) { |i| format '%<account_number>05d', account_number: i }
 
     trait :with_user do
       after(:create) do |instance|

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -27,8 +27,8 @@ class FilterTest < ActiveSupport::TestCase
   let(:account) { FactoryBot.create(:account) }
   let(:msg) do
     Message.new :application => app.name, :event_type => app.event_types.first.external_id,
-                :level => 'critical', :account_id => account.id, :timestamp => Time.zone.now,
-                :message => 'hello'
+                :level => 'critical', :account_id => account.account_number,
+                :timestamp => Time.zone.now, :message => 'hello'
   end
   let(:event_types) { %w[something something-else yet-something-else] }
   let(:levels) { %w[low medium high critical] }

--- a/test/unit/dispatcher_test.rb
+++ b/test/unit/dispatcher_test.rb
@@ -8,7 +8,7 @@ class DispatcherTest < ActiveSupport::TestCase
   let(:filter) { FactoryBot.create(:filter, endpoint: endpoint, account: endpoint.account) }
   let(:msg) do
     Message.new(
-      account_id: endpoint.account_id,
+      account_id: endpoint.account.account_number,
       application: 'app',
       event_type: 'something',
       level: 'low',


### PR DESCRIPTION
When trying to find filters which would match a message, we relied on account_id
in the message being our internal ID. However, the value was in fact the
external account number, which can be seen in the web UI.